### PR TITLE
Replace spark-io with particle-io

### DIFF
--- a/lib/nodebotNode.js
+++ b/lib/nodebotNode.js
@@ -297,13 +297,13 @@ function createNode(RED){
         });
       }
     }
-    else if( 'spark-io' === n.boardType){
+    else if( 'particle-io' === n.boardType){
 
       try{
         node.io = new boardModule({deviceId: n.sparkId, token: n.sparkToken});
         start(node);
       }catch(exp){
-        console.log('error initializing spark-io class', n.boardType, exp);
+        console.log('error initializing particle-io class', n.boardType, exp);
         process.nextTick(function() {
           node.emit('ioError', exp);
         });


### PR DESCRIPTION
I installed node-red, node-red-contrib-gpio, and particle-io Node packages, and I ended up having problems getting my Particle gpio nodes to connect. Turns out that the "nodebot" dropdown in the UI referred to "particle-io" but the code expects "spark-io". I believe "particle-io" is the correct name, but I didn't dig too much.